### PR TITLE
compatible with nightbot(querystring) and id#tag format too

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,24 +7,37 @@ from keep_alive import keep_alive
 import schedule
 import threading
 import time
+from urllib.parse import unquote
 
 app = Flask(__name__)
-
-app.config['DEBUG_REFRESH'] = 10
 
 @app.route("/")
 def home():
     return "Use /lastmatch"
 
+@app.route("/lm/<query>")
+@app.route("/lastmatch/<query>")
+def lastmatch(query):
+    
+        
+    decoded_query = unquote(query)  # Decode the URL-encoded query
+    decoded_query = decoded_query.replace("#", "/")
+    decoded_query = decoded_query.replace(" ","")    # Replace / with # in the query parameter
+    
+    
+    if not decoded_query:
+        decoded_query = 'ggmotato/onyt'
+        query = 'GGMotato#onyt'
 
-@app.route("/lm/")
-@app.route("/lastmatch/")
-@app.route("/lm")
-@app.route("/lastmatch")
-
-
-def lastmatch():
-    external_url = 'https://api.henrikdev.xyz/valorant/v3/matches/ap/neonfrmbigbzar/sasta?size=1'
+    # Split the query into id and tag
+    if "#" in query:
+        id, tag = query.split("#")
+        id = id.replace(" ","")
+        tag = tag.replace(" ","")
+    else:
+        return f"Please Mention #tag."
+    
+    external_url = f'https://api.henrikdev.xyz/valorant/v3/matches/ap/{decoded_query}?size=1'
 
     # Fetch JSON data from the external URL
     response = requests.get(external_url)
@@ -39,80 +52,58 @@ def lastmatch():
 
         # Check if the data list is empty
         if json_dotmap.data and json_dotmap.data[0].players.all_players:
-            # Extract player name from the URL between /ap/ and /onyt/
-            url_parts = external_url.split('/')
-            player_name_from_url = url_parts[url_parts.index('ap') + 1]
-            player_name_from_url = player_name_from_url.replace(" ","")
-
             # Find player by name (case-insensitive and ignoring spaces)
             player_info = None
             for player in json_dotmap.data[0].players.all_players:
                 # Compare names case-insensitive and ignoring spaces
-                if player.name.replace(" ", "").lower() == player_name_from_url.lower():
+                if player.name.replace(" ", "").lower() == id.lower() and player.tag.replace(" ", "").lower() == tag.lower():
                     player_info = player
                     break
 
             if player_info is not None:
-                
                 # Extracting useful metadata information
-                
                 metadata = json_dotmap.data[0].metadata
                 mode = metadata.get("mode", "Unknown Mode")
                 map_name = metadata.get("map", "Unknown Map")
                 server = metadata.get("cluster", "Unknown Map")
-                start_ts = metadata.get("game_start" , None)
+                start_ts = metadata.get("game_start", None)
                 game_len = metadata.get("game_length", None)
-                start_ts += game_len
                 
-
+                start_ts += game_len
 
                 # Agent was picked by player or given by game itself
-                
                 pick_or_got = "picked"
                 if mode.lower() == "deathmatch" or mode.lower() == "escalation":
                     pick_or_got = "got"
                 else:
                     pick_or_got = "picked"
 
-
                 # Extract player's character (agent) and KDA
-                
                 character = player_info.character
                 kda = f"{player_info.stats.kills}/{player_info.stats.deaths}/{player_info.stats.assists}"
-                display_name = player_info.name.replace("  "," ") + "#" + player_info.tag
-
-
+                display_name = player_info.name.replace("  ", " ") + "#" + player_info.tag
 
                 # Time Since last match played
-            
                 start_utc = datetime.datetime.fromtimestamp(start_ts, datetime.timezone.utc)
-
                 ist_tz, now_ist = pytz.timezone('Asia/Kolkata'), datetime.datetime.now(pytz.timezone('Asia/Kolkata'))
-
                 start_ist = start_utc.astimezone(ist_tz)
                 elapsed = now_ist - start_ist
-
 
                 if elapsed.total_seconds() < 60:
                     time = int(elapsed.total_seconds())
                     unit = "s"
-                    # print(f"Player's last match was {int(elapsed.total_seconds())} seconds ago (IST)")
                 elif elapsed.total_seconds() < 3600:
                     time = int(elapsed.total_seconds() // 60)
-                    unit = "m"       
-                    # print(f"Player's last match was {int(elapsed.total_seconds() // 60)} minutes ago (IST)")
+                    unit = "m"
                 elif elapsed.total_seconds() < 86400:
-                    
                     time = round(elapsed.total_seconds() / 3600)
                     unit = "h"
-                    # print(f"Player's last match was {hours} {'hour' if hours == 1 else 'hours'} ago (IST)")  
                 else:
                     days = elapsed.days
                     weeks = days // 7
                     if weeks > 0:
                         time = weeks
                         unit = "w"
-                        #print(f"Player's last match was {weeks} {'week' if weeks == 1 else 'weeks'} ago (IST)")
                     elif days > 0:
                         time = days
                         unit = "d"
@@ -124,10 +115,10 @@ def lastmatch():
                     f"({time}{unit} ago)"
                 )
             else:
-                response_message = f"Player '{player_name_from_url}' not found."
+                response_message = f"Player {id}#{tag} not found."
         else:
             response_message = "Player has not been playing from a long ago"
     else:
-        response_message = f"Failed to fetch data from the external URL. Status Code: {response.status_code}"
-        
+        response_message = f"Invalid Riot ID. Status Code: {response.status_code}"
+
     return response_message


### PR DESCRIPTION
querystring bcz it encodes # to %23 format which is compatible with urls and m not getting a way to do it if its possible...

and i command we have to mention %20 which denotes blank space bcz routes are finding for some path to get and we cant leave it empty so we've to add %20 in nightboit command like this
 $(urlfetch https://velosofy-val-api.glitch.me/lm/%20$(querystring))
 
 if user enters their id tag it will show their stats otherwise ggmotato's stats ( my fav streanmer )
 
 u can make it use for your own too but that will be static 
  $(urlfetch https://velosofy-val-api.glitch.me/lm/GGMotato%23onYT) ~~ id is GGMotato#onYT use %23 at the place of # 